### PR TITLE
Uppercase abbreviations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 #### Usage
 
-* If your csv or tsv file doesn't have "*.csv"("*.tsv") extension, you can manually enable highlighting by clicking on the current language label mark in the right bottom corner and then choosing "csv", "tsv" or "csv (semicolon)" depending on the file content, see this [screenshot](https://stackoverflow.com/a/30776845/2898283)
+* If your csv or tsv file doesn't have "*.csv"("*.tsv") extension, you can manually enable highlighting by clicking on the current language label mark in the right bottom corner and then choosing "CSV", "TSV" or "CSV (semicolon)" depending on the file content, see this [screenshot](https://stackoverflow.com/a/30776845/2898283)
 
 #### References
 

--- a/extension.js
+++ b/extension.js
@@ -62,21 +62,21 @@ function activate(context) {
 
     console.log('Activating "rainbow_csv"');
 
-    csv_provider = vscode.languages.registerHoverProvider('csv', {
+    csv_provider = vscode.languages.registerHoverProvider('CSV', {
         provideHover(document, position, token) {
             hover_text = make_hover_text(document, position, rainbow_utils.split_quoted_str, ',');
             return new vscode.Hover(hover_text);
         }
     });
 
-    tsv_provider = vscode.languages.registerHoverProvider('tsv', {
+    tsv_provider = vscode.languages.registerHoverProvider('TSV', {
         provideHover(document, position, token) {
             hover_text = make_hover_text(document, position, rainbow_utils.split_simple_str, '\t');
             return new vscode.Hover(hover_text);
         }
     });
 
-    scsv_provider = vscode.languages.registerHoverProvider('csv (semicolon)', {
+    scsv_provider = vscode.languages.registerHoverProvider('CSV (semicolon)', {
         provideHover(document, position, token) {
             hover_text = make_hover_text(document, position, rainbow_utils.split_quoted_str, ';');
             return new vscode.Hover(hover_text);

--- a/package.json
+++ b/package.json
@@ -18,34 +18,34 @@
         "Languages"
     ],
     "activationEvents": [
-        "onLanguage:csv", "onLanguage:tsv", "onLanguage:csv (semicolon)"
+        "onLanguage:CSV", "onLanguage:TSV", "onLanguage:CSV (semicolon)"
     ],
     "main": "./extension",
     "contributes": {
         "languages": [{
-            "id": "csv",
+            "id": "CSV",
             "extensions": [".csv"]
         },
         {
-            "id": "tsv",
+            "id": "TSV",
             "extensions": [".tsv"]
         },
         {
-            "id": "csv (semicolon)",
+            "id": "CSV (semicolon)",
             "extensions": [".scsv"]
         }],
         "grammars": [{
-            "language": "csv",
+            "language": "CSV",
             "scopeName": "text.csv",
             "path": "./syntaxes/csv.tmLanguage.json"
         },
         {
-            "language": "tsv",
+            "language": "TSV",
             "scopeName": "text.tsv",
             "path": "./syntaxes/tsv.tmLanguage.json"
         },
         {
-            "language": "csv (semicolon)",
+            "language": "CSV (semicolon)",
             "scopeName": "text.scsv",
             "path": "./syntaxes/scsv.tmLanguage.json"
         }]


### PR DESCRIPTION
It is more convenient to use uppercase abbreviations. Lowercase letters are improperly sorted in language list in VS Code.