### PR TITLE
fix col_num shifting on quoted fields

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -105,7 +105,7 @@ function make_hover_text(document, position, language_id) {
     var cnum = position.character;
     var line = document.lineAt(lnum).text;
 
-    var report = rainbow_utils.smart_split(line, delim, policy, false);
+    var report = rainbow_utils.smart_split(line, delim, policy, true);
 
     var entries = report[0];
     var warning = report[1];


### PR DESCRIPTION
This fixes the issue that column numbers shown on hovertexts are wrong where fields are quoted.

Before:
![image](https://user-images.githubusercontent.com/1079715/41607092-27c4afae-7420-11e8-82f9-a6e06b353771.png)
After:
![image](https://user-images.githubusercontent.com/1079715/41607153-50b7ab5a-7420-11e8-8666-21841a39fde4.png)