### PR TITLE
make csv_encoding configurable

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -576,7 +576,7 @@ function run_rbql_query(active_file_path, backend_language, rbql_query, report_h
     if (backend_language == 'js') {
         run_rbql_native(active_file_path, rbql_query, rbql_context.delim, rbql_context.policy, report_handler, csv_encoding);
     } else {
-        let args = [rbql_exec_path, rbql_context.delim, rbql_context.policy, rbql_query, active_file_path, csv_encoding];
+        let args = [rbql_exec_path, rbql_context.delim, rbql_context.policy, Buffer.from(rbql_query, "utf-8").toString("base64"), active_file_path, csv_encoding];
         run_command(cmd, args, close_and_error_guard, function(error_code, stdout, stderr) { handle_command_result(error_code, stdout, stderr, report_handler); });
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -527,14 +527,13 @@ function get_error_message(error) {
 }
 
 
-function run_rbql_native(input_path, query, delim, policy, report_handler) {
+function run_rbql_native(input_path, query, delim, policy, report_handler, csv_encoding) {
     var rbql_lines = [query];
     var tmp_dir = os.tmpdir();
     var script_filename = 'rbconvert_' + String(Math.random()).replace('.', '_') + '.js';
     var tmp_worker_module_path = path.join(tmp_dir, script_filename);
     var output_delim = delim;
     var output_policy = policy;
-    var csv_encoding = rbql.default_csv_encoding;
 
     var output_file_name = get_dst_table_name(input_path, output_delim);
     var output_path = path.join(tmp_dir, output_file_name);
@@ -564,6 +563,8 @@ function run_rbql_query(active_file_path, backend_language, rbql_query, report_h
     var cmd = 'python';
     const test_marker = 'test ';
     let close_and_error_guard = {'process_reported': false};
+    const config = vscode.workspace.getConfiguration('rainbow_csv');
+    var csv_encoding = config && config.get('rbql_encoding') || rbql.default_csv_encoding;
     if (rbql_query.startsWith(test_marker)) {
         if (rbql_query.indexOf('nopython') != -1) {
             cmd = 'nopython';
@@ -573,9 +574,9 @@ function run_rbql_query(active_file_path, backend_language, rbql_query, report_h
         return;
     }
     if (backend_language == 'js') {
-        run_rbql_native(active_file_path, rbql_query, rbql_context.delim, rbql_context.policy, report_handler);
+        run_rbql_native(active_file_path, rbql_query, rbql_context.delim, rbql_context.policy, report_handler, csv_encoding);
     } else {
-        let args = [rbql_exec_path, rbql_context.delim, rbql_context.policy, rbql_query, active_file_path];
+        let args = [rbql_exec_path, rbql_context.delim, rbql_context.policy, rbql_query, active_file_path, csv_encoding];
         run_command(cmd, args, close_and_error_guard, function(error_code, stdout, stderr) { handle_command_result(error_code, stdout, stderr, report_handler); });
     }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
                         "type": "string",
                         "description": "Separator"
                     }
+                },
+                "rainbow_csv.rbql_encoding": {
+                    "type": "string",
+                    "default": "utf-8",
+                    "description": "Manually set csv table encoding"
                 }
             }
         },

--- a/rbql_core/vscode_rbql.py
+++ b/rbql_core/vscode_rbql.py
@@ -85,13 +85,14 @@ def main():
     parser.add_argument('policy', help='csv split policy', choices=['simple', 'quoted', 'monocolumn'])
     parser.add_argument('query', help='Query string in rbql')
     parser.add_argument('input_table_path', metavar='FILE', help='Read csv table from FILE instead of stdin')
+    parser.add_argument('encoding', help='Manually set csv table encoding')
     args = parser.parse_args()
 
     delim = rbql.normalize_delim(args.delim)
     policy = args.policy
     query = args.query
     input_path = args.input_table_path
-    csv_encoding = rbql.default_csv_encoding
+    csv_encoding = args.encoding
     output_delim, output_policy = delim, policy
 
     output_path = get_dst_table_path(input_path, output_delim)

--- a/rbql_core/vscode_rbql.py
+++ b/rbql_core/vscode_rbql.py
@@ -10,6 +10,7 @@ import tempfile
 import subprocess
 import argparse
 import json
+import base64
 
 import rbql
 
@@ -90,7 +91,7 @@ def main():
 
     delim = rbql.normalize_delim(args.delim)
     policy = args.policy
-    query = args.query
+    query = base64.standard_b64decode(args.query).decode("utf-8")
     input_path = args.input_table_path
     csv_encoding = args.encoding
     output_delim, output_policy = delim, policy


### PR DESCRIPTION
The default encoding of RBQL is latin-1, which is regarded as [one of legacy encodings](https://encoding.spec.whatwg.org/#legacy-single-byte-encodings) and can't handle Unicode characters.
This patch makes csv encoding configurable.

## Screenshots
### JavaScript backend
![image](https://user-images.githubusercontent.com/1079715/52362063-14d38680-2a83-11e9-8fff-9ce2f660f042.png)

### Python backend
![image](https://user-images.githubusercontent.com/1079715/52362530-223d4080-2a84-11e9-85bc-ee75648e1650.png)
The query in this capture uses Unicode escape sequences because Python backend currently can't handle Unicode characters in given queries.