### PR TITLE
Support for comments when linting via added setting comment_symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To remove cursor/selection from the header line use "Alt+Click" on it.
 
 #### SetVirtualHeader
 Adjust column names displayed in hover tooltips. Actual header line and file content won't be affected.  
-Rainbow CSV always assumes the first row as a header, so when there is no real header in a spreadsheet, you can use this command and provide comma-separated string with column names to create a "virtual" header for more comfortable data viewing. Accepted CSV format doesn't require you to customize all of the columns - this is useful when you want to name only some small subset of available columns. Note that you must provide comma-separated string no matter what separator is actually used in your spreadsheet file. "Virtual" header is persistent and will be associated with the parent file across VSCode sessions.
+Rainbow CSV always assumes the first row that is not a comment (if comments are enabled) as a header, so when there is no real header in a spreadsheet, you can use this command and provide comma-separated string with column names to create a "virtual" header for more comfortable data viewing. Accepted CSV format doesn't require you to customize all of the columns - this is useful when you want to name only some small subset of available columns. Note that you must provide comma-separated string no matter what separator is actually used in your spreadsheet file. "Virtual" header is persistent and will be associated with the parent file across VSCode sessions.
 
 ### Colors customization 
 You can customize Rainbow CSV colors to increase contrast. [Instructions](test/color_customization_example.md#colors-customization)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The linter will check the following:
 To disable automatic CSV Linting set `"rainbow_csv.enable_auto_csv_lint": false` in "Rainbow CSV" section of VS Code settings.  
 To recheck a csv file click on "CSVLint" button.
 
+If `"rainbow_csv.comment_prefix"` in "Rainbow CSV" section of VS Code settings is set to some string, the linter will ignore all lines that start with it.
+This is useful, e.g., if you have engineering CSVs that often start with multiple comment lines containing meta-data before the actual header.
+
 
 #### Working with large files
 To enable Rainbow CSV for very big files (more than 300K lines or 20MB) disable "Editor:Large File Optimizations" option in VS Code settings.  

--- a/extension.js
+++ b/extension.js
@@ -66,7 +66,7 @@ var global_state = null;
 
 var preview_panel = null;
 
-var comment_symbol ='#';
+var comment_prefix = '#';
 
 
 function dbg_log(msg) {
@@ -128,12 +128,12 @@ function sample_preview_records_from_context(rbql_context) {
 }
 
 function get_header_line(document) {
-    if (!comment_symbol)
+    if (!comment_prefix)
         return document.lineAt(0).text;
     const num_lines = document.lineCount;
-    for(let lnum = 0; lnum < num_lines; ++lnum) {
+    for (let lnum = 0; lnum < num_lines; ++lnum) {
         const line_text = document.lineAt(lnum).text;
-        if (line_text[0] !== comment_symbol) {
+        if (!line_text.startsWith(comment_prefix)) {
             return line_text;
         }
     }
@@ -172,7 +172,7 @@ function make_hover_text(document, position, language_id) {
     var cnum = position.character;
     var line = document.lineAt(lnum).text;
 
-    if (line[0] === comment_symbol)
+    if (comment_prefix && line.startsWith(comment_prefix))
         return 'Comment';
 
     var report = rainbow_utils.smart_split(line, delim, policy, true);
@@ -223,7 +223,7 @@ function produce_lint_report(active_doc, delim, policy, max_check_size) {
         var line_text = active_doc.lineAt(lnum).text;
         if (lnum + 1 == num_lines && !line_text)
             break;
-        if (line_text[0] === comment_symbol)
+        if (comment_prefix && line_text.startsWith(comment_prefix))
             continue;
         var split_result = rainbow_utils.smart_split(line_text, delim, policy, false);
         if (split_result[1]) {
@@ -842,7 +842,7 @@ function column_edit(edit_mode) {
         let line_text = active_doc.lineAt(lnum).text;
         if (lnum + 1 == num_lines && !line_text)
             break;
-        if (line_text[0] === comment_symbol)
+        if (comment_prefix && line_text.startsWith(comment_prefix))
             continue;
         let report = rainbow_utils.smart_split(line_text, delim, policy, true);
         let entries = report[0];
@@ -988,7 +988,7 @@ function is_delimited_table(active_doc, delim, policy) {
         var line_text = active_doc.lineAt(lnum).text;
         if (lnum + 1 == num_lines && !line_text)
             break;
-        if (line_text[0] === comment_symbol)
+        if (comment_prefix && line_text.startsWith(comment_prefix))
             continue;
         let [fields, warning] = rainbow_utils.smart_split(line_text, delim, policy, true);
         if (warning)
@@ -1156,7 +1156,7 @@ function activate(context) {
             enable_tooltip_column_names = false;
         if (config.get('enable_tooltip_warnings') === false)
             enable_tooltip_warnings = false;
-        comment_symbol = config.get('comment_symbol');
+        comment_prefix = config.get('comment_prefix');
     }
 
     global_state = context.globalState;

--- a/extension.js
+++ b/extension.js
@@ -66,6 +66,8 @@ var global_state = null;
 
 var preview_panel = null;
 
+var comment_symbol ='#';
+
 
 function dbg_log(msg) {
     if (!enable_dev_mode)
@@ -125,6 +127,18 @@ function sample_preview_records_from_context(rbql_context) {
     return preview_records;
 }
 
+function get_header_line(document) {
+    if (!comment_symbol)
+        return document.lineAt(0).text;
+    const num_lines = document.lineCount;
+    for(let lnum = 0; lnum < num_lines; ++lnum) {
+        const line_text = document.lineAt(lnum).text;
+        if (line_text[0] !== comment_symbol) {
+            return line_text;
+        }
+    }
+    return null;
+}
 
 function get_header(document, delim, policy) {
     var file_path = document.fileName;
@@ -134,7 +148,7 @@ function get_header(document, delim, policy) {
             return rainbow_utils.smart_split(header, ',', 'quoted', false)[0];
         }
     }
-    return rainbow_utils.smart_split(document.lineAt(0).text, delim, policy, false)[0];
+    return rainbow_utils.smart_split(get_header_line(document), delim, policy, false)[0];
 }
 
 
@@ -157,6 +171,9 @@ function make_hover_text(document, position, language_id) {
     var lnum = position.line;
     var cnum = position.character;
     var line = document.lineAt(lnum).text;
+
+    if (line[0] === comment_symbol)
+        return 'Comment';
 
     var report = rainbow_utils.smart_split(line, delim, policy, true);
 
@@ -206,12 +223,15 @@ function produce_lint_report(active_doc, delim, policy, max_check_size) {
         var line_text = active_doc.lineAt(lnum).text;
         if (lnum + 1 == num_lines && !line_text)
             break;
+        if (line_text[0] === comment_symbol)
+            continue;
         var split_result = rainbow_utils.smart_split(line_text, delim, policy, false);
         if (split_result[1]) {
             return 'Error. Line ' + (lnum + 1) + ' has formatting error: double quote chars are not consistent';
         }
-        if (lnum === 0)
+        if (!num_fields) {
             num_fields = split_result[0].length;
+        }
         if (num_fields != split_result[0].length) {
             return 'Error. Number of fields is not consistent: e.g. line 1 has ' + num_fields + ' fields, and line ' + (lnum + 1) + ' has ' + split_result[0].length + ' fields.';
         }
@@ -822,6 +842,8 @@ function column_edit(edit_mode) {
         let line_text = active_doc.lineAt(lnum).text;
         if (lnum + 1 == num_lines && !line_text)
             break;
+        if (line_text[0] === comment_symbol)
+            continue;
         let report = rainbow_utils.smart_split(line_text, delim, policy, true);
         let entries = report[0];
         quoting_warning = quoting_warning || report[1];
@@ -966,6 +988,8 @@ function is_delimited_table(active_doc, delim, policy) {
         var line_text = active_doc.lineAt(lnum).text;
         if (lnum + 1 == num_lines && !line_text)
             break;
+        if (line_text[0] === comment_symbol)
+            continue;
         let [fields, warning] = rainbow_utils.smart_split(line_text, delim, policy, true);
         if (warning)
             return false; // TODO don't fail on warnings in future versions
@@ -1132,6 +1156,7 @@ function activate(context) {
             enable_tooltip_column_names = false;
         if (config.get('enable_tooltip_warnings') === false)
             enable_tooltip_warnings = false;
+        comment_symbol = config.get('comment_symbol');
     }
 
     global_state = context.globalState;

--- a/extension.js
+++ b/extension.js
@@ -68,7 +68,6 @@ var preview_panel = null;
 
 var comment_prefix = '#';
 
-
 function dbg_log(msg) {
     if (!enable_dev_mode)
         return;

--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
                     "type": "string",
                     "default": "utf-8",
                     "description": "Manually set csv table encoding"
+                },
+                "rainbow_csv.comment_symbol": {
+                    "type": "string",
+                    "default": "#",
+                    "description": "Comment symbol (none means no comments allowed)"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -85,10 +85,10 @@
                     "default": "utf-8",
                     "description": "Manually set csv table encoding"
                 },
-                "rainbow_csv.comment_symbol": {
+                "rainbow_csv.comment_prefix": {
                     "type": "string",
                     "default": "#",
-                    "description": "Comment symbol (none means no comments allowed)"
+                    "description": "Comment prefix to denote lines that should be ignored when linting"
                 }
             }
         },


### PR DESCRIPTION
This is a tiny fix for the linter warnings when there are comments at the beginning (see issue [14](https://github.com/mechatroner/vscode_rainbow_csv/issues/14)).