### PR TITLE
Add SetHeaderLine command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ To remove cursor/selection from the header line use "Alt+Click" on it.
 Input a comma-separated string with column names to adjust column names displayed in hover tooltips. Actual header line and file content won't be affected.
 "Virtual" header is persistent and will be associated with the parent file across VSCode sessions.
 
+#### SetHeaderLine 
+Uses the current line to adjust column names displayed in hover tooltips. Actual header line and file content won't be affected.
+This is a "Virtual" header and will be persistent and will be associated with the parent file across VSCode sessions.
+
 #### SetJoinTableName
 Set a custom name for the current file so you can use it instead of the file path in RBQL JOIN queries
 

--- a/extension.js
+++ b/extension.js
@@ -837,6 +837,20 @@ function get_dialect(document) {
     return dialect_map[language_id];
 }
 
+function set_header_line() {
+    let active_editor = get_active_editor();
+    if (!active_editor)
+        return;
+    var active_doc = get_active_doc(active_editor);
+    if (!active_doc)
+        return;
+
+    let file_path = active_doc.fileName;
+    let selection = active_editor.selection;
+    let header = active_doc.lineAt(selection.start.line).text;
+
+    save_to_global_state(make_header_key(file_path), header);
+}
 
 function set_rainbow_separator() {
     let active_editor = get_active_editor();
@@ -1510,6 +1524,7 @@ function activate(context) {
 
     var lint_cmd = vscode.commands.registerCommand('extension.CSVLint', csv_lint_cmd);
     var rbql_cmd = vscode.commands.registerCommand('extension.RBQL', edit_rbql);
+    var set_header_line_cmd = vscode.commands.registerCommand('extension.SetHeaderLine', set_header_line);
     var edit_column_names_cmd = vscode.commands.registerCommand('extension.SetVirtualHeader', edit_column_names);
     var set_join_table_name_cmd = vscode.commands.registerCommand('extension.SetJoinTableName', set_join_table_name);
     var column_edit_before_cmd = vscode.commands.registerCommand('extension.ColumnEditBefore', function() { column_edit('ce_before'); });
@@ -1542,6 +1557,7 @@ function activate(context) {
     context.subscriptions.push(align_cmd);
     context.subscriptions.push(shrink_cmd);
     context.subscriptions.push(copy_back_cmd);
+    context.subscriptions.push(set_header_line_cmd);
 
     setTimeout(function() {
         // Need this because "onDidOpenTextDocument()" doesn't get called for the first open document

--- a/package.json
+++ b/package.json
@@ -115,6 +115,11 @@
                     "when": "editorHasSelection",
                     "command": "extension.RainbowSeparator",
                     "group": "rainbow_csv"
+                },
+                {
+                    "when": "editorTextFocus",
+                    "command": "extension.SetHeaderLine",
+                    "group": "rainbow_csv"
                 }
             ],
             "explorer/context": [
@@ -246,6 +251,11 @@
                 "command": "extension.SetVirtualHeader",
                 "category": "Rainbow CSV",
                 "title": "Set virtual header"
+            },
+            {
+                "command": "extension.SetHeaderLine",
+                "category": "Rainbow CSV",
+                "title": "Set header line"
             },
             {
                 "command": "extension.RBQL",


### PR DESCRIPTION
This adds a SetHeaderLine that will use the currently selected line as a header. This allows the user to easily work around issues posed in #13 and #14. This is also added to the editor context menu to allow users to right click.