### PR TITLE
Limit visibility of editor context menu commands to show only for CSV files

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,12 +124,12 @@
         "menus": {
             "editor/context": [
                 {
-                    "when": "editorHasSelection",
+                    "when": "editorHasSelection && editorLangId =~ /^[ct]sv/",
                     "command": "rainbow-csv.RainbowSeparator",
                     "group": "rainbow_csv"
                 },
                 {
-                    "when": "editorTextFocus",
+                    "when": "editorTextFocus && editorLangId =~ /^[ct]sv/",
                     "command": "rainbow-csv.SetHeaderLine",
                     "group": "rainbow_csv"
                 }


### PR DESCRIPTION
This prevents the "Set Header Line" and rainbow separator context menus from showing on all files and limits them to only activate when the current language is a CSV variant.