### PR TITLE
Fix null property access error

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1593,7 +1593,7 @@ async function handle_doc_open(active_doc) {
     // This behavior is called Preview Mode, see https://vscode.one/new-tab-vscode/ and https://code.visualstudio.com/docs/getstarted/userinterface#_preview-mode
 
     // We got an invalid document object, processing will lead to null access errors below
-    if (active_doc === undefined || active_doc.uri === undefined) {
+    if (!active_doc || !active_doc.uri) {
         return;
     }
 


### PR DESCRIPTION
I've been seeing 
```
TypeError: Cannot read properties of null (reading 'uri')
extensionHostProcess.js:102
stack trace: TypeError: Cannot read properties of null (reading 'uri')
    at handle_doc_open (/Users/lramos15/.vscode-insiders/extensions/mechatroner.rainbow-csv-3.5.0/extension.js:1595:20)
```
in my console a bunch lately. This points to the following line, so I've added a guard above to not access the URI of a non existing document