### PR TITLE
feat: Tweak inlays

### DIFF
--- a/rainbow_utils.js
+++ b/rainbow_utils.js
@@ -334,12 +334,16 @@ function generate_inlay_hints(vscode, table_ranges, all_columns_stats) {
                 let is_last_in_line = is_last_field || i + 1 < field_segments.length;
                 let [num_before, num_after] = evaluate_rfc_align_field(field_segments[i], is_first_record, all_columns_stats[fnum], is_field_segment, is_last_in_line);
                 if (num_before > 0) {
-                    let hint_label = ' '.repeat(num_before);
+                    let hint_label = '\u00b7'.repeat(num_before); // Middle dot character
                     inlay_hints.push(new vscode.InlayHint(field_segment_range.start, hint_label));
                 }
-                if (num_after > 0) {
-                    let hint_label = ' '.repeat(num_after);
-                    inlay_hints.push(new vscode.InlayHint(field_segment_range.end, hint_label));
+                if (num_after > 1) {
+                    let hint_label = '\u00b7'.repeat(num_after - 1); // Middle dot character
+
+                    let pos = field_segment_range.end;
+                    // Exclude comma from inlay, move pos left by one
+                    let inlay_pos = new vscode.Position(pos.line, pos.character - 1);
+                    inlay_hints.push(new vscode.InlayHint(inlay_pos, hint_label));
                 }
             }
         }


### PR DESCRIPTION
I find a dot character easier to parse that blank whitespace. Should we make this configurable?

This restores the alignment to add space before the comma, as in https://github.com/mechatroner/vscode_rainbow_csv/issues/80#issuecomment-2566359634 . Same question -- make default, add config option?

<img width="492" alt="image" src="https://github.com/user-attachments/assets/4c2f1777-90fc-4338-9ca6-f67cd132b479" />
