### PR TITLE
Support multiline fields in Excel export copy

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2545,16 +2545,7 @@ async function do_excel_copy(log_wrapper) {
     for (let row_info of row_infos) {
         let fields = [];
         for (let field_segments of row_info.record_fields) {
-            if (field_segments.length != 1) {
-                show_single_line_error('Unable to copy fragment with multiline fields');
-                return;
-            }
-            let field_for_copy = field_segments[0];
-            if (field_for_copy.includes('\t')) {
-                show_single_line_error('Unable to copy fragment containing tabs inside some of the fields because it will interfere with the resulting table structure');
-                return;
-            }
-            fields.push(field_for_copy);
+            fields.push(csv_utils.rfc_quote_field(csv_utils.unquote_field(field_segments.join('\n')), '\t'));
         }
         tsv_lines.push(fields.join('\t'));
     }

--- a/test/csv_files/excel_copy_multiline.csv
+++ b/test/csv_files/excel_copy_multiline.csv
@@ -1,0 +1,12 @@
+name,note,status
+alpha,"line 1
+line 2",ok
+bravo,"contains	tab",ok
+charlie,"say ""hello""",ok
+delta,plain,ok
+echo,plain,ok
+foxtrot,plain,ok
+golf,plain,ok
+hotel,plain,ok
+india,plain,ok
+juliet,plain,ok

--- a/test/suite/index.js
+++ b/test/suite/index.js
@@ -553,6 +553,38 @@ async function test_excel_copy(test_folder_uri) {
 }
 
 
+async function test_excel_copy_multiline(test_folder_uri) {
+    let uri = vscode.Uri.joinPath(test_folder_uri, 'csv_files', 'excel_copy_multiline.csv');
+    let active_doc = await vscode.workspace.openTextDocument(uri);
+    let editor = await vscode.window.showTextDocument(active_doc);
+    await sleep(2000);
+    if (active_doc.languageId != 'dynamic csv') {
+        let dialect_test_task = {'integration_test': true};
+        await vscode.commands.executeCommand('rainbow-csv.RainbowSeparator', dialect_test_task);
+        await sleep(4000);
+    }
+    assert.equal(active_doc.languageId, 'dynamic csv');
+    log_message('Testing Excel Copy with multiline fields');
+    await vscode.commands.executeCommand('rainbow-csv.ExcelCopy');
+    await sleep(500);
+    let export_text = await vscode.env.clipboard.readText();
+    assert.equal(export_text, [
+        'name\tnote\tstatus',
+        'alpha\t"line 1\nline 2"\tok',
+        'bravo\t"contains\ttab"\tok',
+        'charlie\t"say ""hello"""\tok',
+        'delta\tplain\tok',
+        'echo\tplain\tok',
+        'foxtrot\tplain\tok',
+        'golf\tplain\tok',
+        'hotel\tplain\tok',
+        'india\tplain\tok',
+        'juliet\tplain\tok',
+    ].join('\n'));
+    log_message('Finished Excel Copy Multiline Test');
+}
+
+
 async function test_dynamic_csv(test_folder_uri) {
     let uri = vscode.Uri.joinPath(test_folder_uri, 'csv_files', 'movies_multichar_separator.txt');
     let active_doc = await vscode.workspace.openTextDocument(uri);
@@ -1107,6 +1139,7 @@ async function run() {
 
         await test_markdown_copy(test_folder_uri);
         await test_excel_copy(test_folder_uri);
+        await test_excel_copy_multiline(test_folder_uri);
 
         await test_huge_file(test_folder_uri);
 


### PR DESCRIPTION
## Summary

- Re-encode parsed fields as TSV cells in `ExcelCopy`
- Preserve quoted multiline fields, tabs, and double quotes when copying for Excel / Sheets
- Add an integration test covering multiline, tab-containing, and quoted fields

## Notes

This keeps the existing `dynamic csv` / `quoted_rfc` behavior intact. The change is limited to the `Copy for Excel / Sheets export` serialization path after records have already been parsed.

## Test

- `npm run unit-test-only`
- `git diff --check`
- `npm test`
  - The new `Testing Excel Copy with multiline fields` case passes.
  - The full suite later hits an existing Python RBQL test issue in this local environment: `activeTextEditor` is undefined in `test_comment_prefix_python_rbql`.